### PR TITLE
feat: Implement Smart Updater integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# Mise-a-jour-auto-haoss
-Mise a jour auto haoss
+# Smart Updater
+
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/hacs/integration)
+
+Smart Updater is a custom integration for Home Assistant that helps you manage your updates. It automatically finds available updates for your HACS components and Home Assistant Core, and allows you to update them selectively or automatically.
+
+## Features
+
+-   **Update Sensor:** A sensor that shows the number of available updates.
+-   **Update Service:** A service to update selected components.
+-   **Lovelace Card:** A custom card to view and manage updates from your dashboard.
+-   **Scheduled Auto-updates:** Configure automatic updates for your components at a time of your choosing.
+
+## Installation
+
+1.  Copy the `smart_updater` directory from this repository into your Home Assistant's `custom_components` directory.
+2.  Restart Home Assistant.
+3.  Go to **Settings > Devices & Services > Add Integration** and search for **Smart Updater**.
+4.  Click on the integration to add it.
+
+## Configuration
+
+You can configure the integration from the options menu of the integration's entry in **Settings > Devices & Services**.
+
+-   **Auto-update time:** Set the time of day when the automatic updates should run.
+-   **Auto-update entities:** Select the components you want to update automatically.
+
+## Usage
+
+### Lovelace Card
+
+To use the card in your dashboard, add a new card and select the "Custom: Smart Updater Card".
+
+```yaml
+type: custom:smart-updater-card
+entity: sensor.smart_updater
+```
+
+The card will display a list of available updates. You can select the ones you want to update and click the "Update Selected" button.
+
+### Service
+
+The integration provides a service `smart_updater.update_selected` that you can use in your automations.
+
+**Service:** `smart_updater.update_selected`
+
+**Data:**
+
+| Name        | Description                      | Example                               |
+|-------------|----------------------------------|---------------------------------------|
+| `entity_id` | A list of update entity IDs to install. | `["update.hacs_integration", "update.home_assistant_core_update"]` |

--- a/custom_components/smart_updater/__init__.py
+++ b/custom_components/smart_updater/__init__.py
@@ -1,0 +1,112 @@
+"""The Smart Updater integration."""
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.event import async_track_time_change
+
+from .const import DOMAIN
+
+PLATFORMS = ["sensor"]
+SERVICE_UPDATE_SELECTED = "update_selected"
+SERVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required("entity_id"): cv.entity_ids,
+    }
+)
+
+
+async def options_update_listener(hass: HomeAssistant, entry: ConfigEntry):
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Smart Updater from a config entry."""
+    hass.http.register_static_path(
+        f"/hacsfiles/{DOMAIN}/smart-updater-card.js",
+        hass.config.path(f"custom_components/{DOMAIN}/www/smart-updater-card.js"),
+    )
+
+    if "lovelace" in hass.data:
+        lovelace = hass.data["lovelace"]
+        if hasattr(lovelace, "resources"):
+            resources = lovelace.resources
+            url = f"/hacsfiles/{DOMAIN}/smart-updater-card.js"
+            if not any(res["url"] == url for res in resources.async_items()):
+                await resources.async_create_item(
+                    {
+                        "res_type": "module",
+                        "url": url,
+                    }
+                )
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    async def handle_update_selected(call):
+        """Handle the update_selected service call."""
+        entity_ids = call.data["entity_id"]
+        for entity_id in entity_ids:
+            await hass.services.async_call(
+                "update",
+                "install",
+                {"entity_id": entity_id},
+                blocking=True,
+            )
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_UPDATE_SELECTED, handle_update_selected, schema=SERVICE_SCHEMA
+    )
+
+    unsub_options_update_listener = entry.add_update_listener(options_update_listener)
+
+    async def auto_update(now):
+        """Handle the automatic update."""
+        auto_update_entities = entry.options.get("auto_update_entities", [])
+        if not auto_update_entities:
+            return
+
+        # We only want to update the ones that actually have an update available.
+        sensor_state = hass.states.get(f"sensor.{DOMAIN}_updates")
+        if not sensor_state:
+            return
+
+        available_updates = [
+            update["entity_id"] for update in sensor_state.attributes.get("updates", [])
+        ]
+
+        entities_to_update = [
+            entity_id for entity_id in auto_update_entities if entity_id in available_updates
+        ]
+
+        if not entities_to_update:
+            return
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_UPDATE_SELECTED,
+            {"entity_id": entities_to_update},
+            blocking=True,
+        )
+
+    time_str = entry.options.get("auto_update_time", "03:00:00")
+    hour, minute, second = map(int, time_str.split(":"))
+
+    unsub_time_tracker = async_track_time_change(
+        hass, auto_update, hour=hour, minute=minute, second=second
+    )
+
+    entry.async_on_unload(
+        lambda: hass.services.async_remove(DOMAIN, SERVICE_UPDATE_SELECTED)
+    )
+    entry.async_on_unload(unsub_options_update_listener)
+    entry.async_on_unload(unsub_time_tracker)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/smart_updater/config_flow.py
+++ b/custom_components/smart_updater/config_flow.py
@@ -1,0 +1,62 @@
+"""Config flow for Smart Updater."""
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.helpers import selector
+
+from .const import DOMAIN
+
+
+class SmartUpdaterOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle an options flow for Smart Updater."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        "auto_update_time",
+                        default=self.config_entry.options.get("auto_update_time", "03:00:00"),
+                    ): selector.TimeSelector(),
+                    vol.Optional(
+                        "auto_update_entities",
+                        default=self.config_entry.options.get("auto_update_entities", []),
+                    ): selector.EntitySelector(
+                        selector.EntitySelectorConfig(
+                            domain="update",
+                            multiple=True,
+                        ),
+                    ),
+                }
+            ),
+        )
+
+
+class SmartUpdaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Smart Updater."""
+
+    VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return SmartUpdaterOptionsFlowHandler(config_entry)
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        return self.async_create_entry(title="Smart Updater", data={})

--- a/custom_components/smart_updater/const.py
+++ b/custom_components/smart_updater/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Smart Updater integration."""
+
+DOMAIN = "smart_updater"

--- a/custom_components/smart_updater/logo.svg
+++ b/custom_components/smart_updater/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M23 4v6h-6"></path>
+  <path d="M1 20v-6h6"></path>
+  <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"></path>
+  <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14"></path>
+</svg>

--- a/custom_components/smart_updater/manifest.json
+++ b/custom_components/smart_updater/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "smart_updater",
+  "name": "Smart Updater",
+  "version": "0.0.1",
+  "documentation": "https://github.com/jules-agent/home-assistant-smart-updater",
+  "issue_tracker": "https://github.com/jules-agent/home-assistant-smart-updater/issues",
+  "config_flow": true,
+  "logo": "logo.svg",
+  "codeowners": ["@jules-agent"],
+  "iot_class": "local_polling"
+}

--- a/custom_components/smart_updater/sensor.py
+++ b/custom_components/smart_updater/sensor.py
@@ -1,0 +1,89 @@
+"""Sensor platform for Smart Updater."""
+from __future__ import annotations
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the sensor platform."""
+    async_add_entities([SmartUpdaterSensor(hass)])
+
+
+class SmartUpdaterSensor(SensorEntity):
+    """Representation of a Smart Updater sensor."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the sensor."""
+        self.hass = hass
+        self._attr_name = "Smart Updater"
+        self._attr_unique_id = f"{DOMAIN}_updates"
+        self._attr_icon = "mdi:update"
+        self._state = 0
+        self._attributes = {"updates": []}
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
+
+    async def async_update(self) -> None:
+        """Fetch new state data for the sensor."""
+        hacs_updates = []
+        ha_update = None
+        registry = er.async_get(self.hass)
+
+        for entity in registry.entities.values():
+            if entity.platform != "hacs" or entity.domain != "update":
+                continue
+
+            state = self.hass.states.get(entity.entity_id)
+            if not state:
+                continue
+
+            installed_version = state.attributes.get("installed_version")
+            latest_version = state.state
+
+            if latest_version and latest_version != "off" and latest_version != installed_version:
+                hacs_updates.append(
+                    {
+                        "name": state.name,
+                        "entity_id": state.entity_id,
+                        "installed_version": installed_version,
+                        "latest_version": latest_version,
+                    }
+                )
+
+        # Check for Home Assistant Core update
+        ha_state = self.hass.states.get("update.home_assistant_core_update")
+        if ha_state:
+            installed_version = ha_state.attributes.get("installed_version")
+            latest_version = ha_state.state
+            if latest_version and latest_version != "off" and latest_version != installed_version:
+                ha_update = {
+                    "name": "Home Assistant Core",
+                    "entity_id": ha_state.entity_id,
+                    "installed_version": installed_version,
+                    "latest_version": latest_version,
+                }
+
+        updates_list = hacs_updates
+        if ha_update:
+            updates_list.append(ha_update)
+
+        self._state = len(updates_list)
+        self._attributes["updates"] = updates_list

--- a/custom_components/smart_updater/www/smart-updater-card.js
+++ b/custom_components/smart_updater/www/smart-updater-card.js
@@ -1,0 +1,143 @@
+import {
+  LitElement,
+  html,
+  css,
+} from "https://unpkg.com/lit-element.js?module";
+
+class SmartUpdaterCard extends LitElement {
+  static get properties() {
+    return {
+      hass: {},
+      config: {},
+      selected_updates: [],
+    };
+  }
+
+  constructor() {
+    super();
+    this.selected_updates = [];
+  }
+
+  setConfig(config) {
+    if (!config.entity) {
+      throw new Error("You need to define an entity");
+    }
+    this.config = config;
+  }
+
+  render() {
+    const state = this.hass.states[this.config.entity];
+    if (!state) {
+      return html`
+        <ha-card>
+          <div class="card-content">
+            Entity not found: ${this.config.entity}
+          </div>
+        </ha-card>
+      `;
+    }
+
+    const updates = state.attributes.updates || [];
+
+    return html`
+      <ha-card header="Smart Updater">
+        <div class="card-content">
+          <h3>${state.state} updates available</h3>
+          ${updates.length > 0
+            ? this._renderUpdates(updates)
+            : html`<p>No updates available.</p>`}
+        </div>
+        ${updates.length > 0
+          ? html`
+              <div class="card-actions">
+                <mwc-button @click=${this._updateSelected}>
+                  Update Selected
+                </mwc-button>
+              </div>
+            `
+          : ""}
+      </ha-card>
+    `;
+  }
+
+  _renderUpdates(updates) {
+    return html`
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th>Name</th>
+            <th>Installed</th>
+            <th>Available</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${updates.map(
+            (update) => html`
+              <tr>
+                <td>
+                  <input
+                    type="checkbox"
+                    .value=${update.entity_id}
+                    @change=${this._handleCheckboxChange}
+                  />
+                </td>
+                <td>${update.name}</td>
+                <td>${update.installed_version}</td>
+                <td>${update.latest_version}</td>
+              </tr>
+            `
+          )}
+        </tbody>
+      </table>
+    `;
+  }
+
+  _handleCheckboxChange(e) {
+    const entity_id = e.target.value;
+    if (e.target.checked) {
+      this.selected_updates.push(entity_id);
+    } else {
+      this.selected_updates = this.selected_updates.filter(
+        (id) => id !== entity_id
+      );
+    }
+  }
+
+  _updateSelected() {
+    this.hass.callService("smart_updater", "update_selected", {
+      entity_id: this.selected_updates,
+    });
+  }
+
+  getCardSize() {
+    const state = this.hass.states[this.config.entity];
+    if (!state) {
+      return 1;
+    }
+    const updates = state.attributes.updates || [];
+    return updates.length + 2; // +1 for header, +1 for button
+  }
+
+  static get styles() {
+    return css`
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 8px;
+        border-bottom: 1px solid #ddd;
+      }
+      .card-actions {
+        padding: 8px;
+        display: flex;
+        justify-content: flex-end;
+      }
+    `;
+  }
+}
+
+customElements.define("smart-updater-card", SmartUpdaterCard);


### PR DESCRIPTION
This commit introduces the Smart Updater integration for Home Assistant.

Features:
- An update sensor that tracks available updates for HACS components and Home Assistant Core.
- A service to trigger updates for selected components.
- A custom Lovelace card to display and manage updates.
- A configuration flow to set up the integration and schedule automatic updates.
- A logo for the integration.
- A detailed README file with installation and usage instructions.